### PR TITLE
Trival spelling mistake fix to "couldnt"

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -290,7 +290,7 @@ void page_write_disk(void *confg)
 
 	ret = pthread_sigmask(SIG_BLOCK, &sigmask, NULL);
 	if (ret)
-		printf("page_write_disk: couldnt mask signals. err:%d\n", ret);
+		printf("page_write_disk: couldn't mask signals. err:%d\n", ret);
 
 	do {
 		int wr_sz;


### PR DESCRIPTION
Minor change, fix spelling of couldnt to couldn't

Signed-off-by: Colin Ian King <colin.king@canonical.com>