### PR TITLE
perf_msr: fix incorrect null pointer check

### DIFF
--- a/src/perf_msr.c
+++ b/src/perf_msr.c
@@ -86,7 +86,7 @@ int init_delta_vars(int n)
 	last_mperf = malloc(sizeof(uint64_t) * n);
 	last_pperf = malloc(sizeof(uint64_t) * n);
 	last_tsc = malloc(sizeof(uint64_t) * n);
-	if (!last_aperf || !last_mperf || !last_mperf || !last_tsc) {
+	if (!last_aperf || !last_mperf || !last_pperf || !last_tsc) {
 		printf("malloc failure perf vars\n");
 		return 0;
 	}


### PR DESCRIPTION
The null pointer check on last_pperf is missing due to a typo on a duplicated null pointer check on last_mperf. Fix this.