### PR TITLE
parse_config: limit sscanf %s size to avoid buffer overflow in buf

### DIFF
--- a/src/parse_config.c
+++ b/src/parse_config.c
@@ -287,7 +287,7 @@ int parse_cmd_config(int ac, char **av, struct config *configp)
 				return 0;
 			break;
 		case 'C':
-			sscanf(optarg, "%s", buf);
+			sscanf(optarg, "%127s", buf);
 			if (set_cpu_mask(buf, configp) < 0)
 				return 0;
 			break;


### PR DESCRIPTION
Limit the sscanf %s scan size to 127 bytes (buf size - 1) to ensure string and end of string marker '\0' can fit into the 128 byte buf to avoid buffer overflow.