### PR TITLE
logger.c: fix unnecessary file descriptor check whether it's equal to zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION = 2.1
 BINDIR = /usr/bin
 MANDIR = /usr/share/man/man1
 WARNFLAGS = -Wall -Wformat
-CC = gcc
+CC ?= gcc
 CFLAGS += -D VERSION=\"$(VERSION)\"
 CFLAGS += -D_LINUX_ -Wall -O2 -Wfloat-equal
 DBG_CFLAGS = -DDEBUG -g -O0

--- a/src/logger.c
+++ b/src/logger.c
@@ -188,7 +188,7 @@ int find_path(char *base, char *node, char *match, char *replace, char *buf)
 		return -1;
 	do {
 		fd = open(token, O_RDONLY);
-		if (fd >= 0) {
+		if (fd != -1) {
 			sz = read(fd, value, sizeof(value));
 			close(fd);
 		}


### PR DESCRIPTION
Hello,
In `logger.c`, at line 191, a check has been done to see if the file descriptor is equal to zero (or larger than zero). POSIX standard has a vague explanation of [return value](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/). However, `0`, `1`, and `2` generally refer to `stdin`, `stdout`, and `stderr`. Opening a file from the file system, will not return such a file descriptor (e.g. `stdin`) unless the input is taken directly from the console, which in this scenario, doesn't.

Since `open()` returns `-1` on error, asserting it will be enough.

Also, `Makefile` explicitly states GCC as the compiler, however, some Linux distributions (such as Chimera Linux) use Clang as their default compiler. Since psst doesn't have any series of GCC-only builtin functions, checking whether `CC` is available should be enough, and if not, it will drop back to GCC.  